### PR TITLE
Use `read_exact`, `write_all`, and `zeroed`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ impl Client {
 
                     let mut header_buf : [u8; HEADER_SIZE] = [0; HEADER_SIZE];
 
-                    match rd_stream.read(&mut header_buf).await {
+                    match rd_stream.read_exact(&mut header_buf).await {
                         Ok(0) => {
                            warn!("[0] Incoming ADS response - no bytes to read");
                         }
@@ -239,9 +239,9 @@ impl Client {
                 
                 ProcessStateMachine::ReadPayload {len_payload, err_code, invoke_id, cmd} => {
                     
-                    let mut payload = BytesMut::with_capacity(*len_payload);
+                    let mut payload = BytesMut::zeroed(*len_payload);
 
-                    match rd_stream.read_buf(&mut payload).await {
+                    match rd_stream.read_exact(&mut payload[..]).await {
                         Ok(0) => {
                             info!("[1] ADS response {:?}, Invoke ID: {:?}: - zero payload", cmd, invoke_id);
                             state = ProcessStateMachine::ReadHeader;
@@ -291,7 +291,7 @@ impl Client {
 
                     match wrt_stream {
                         Ok(ref mut stream) => {
-                            stream.write(data).await?;
+                            stream.write_all(data).await?;
                         },
                         Err(_) => {
                             return Err( AdsError { n_error : 10, s_msg : String::from("Writing to Tcp Stream socket failed") } );


### PR DESCRIPTION
Hi, thanks for the `ads_client` library!

I'm trying to use this crate instead the [`ads`](https://crates.io/crates/ads) crate for a [higher-level library](https://github.com/openstarnz/ads-client/), but am so far having some trouble.

If it's okay, I'd like to make some pull requests, each targeting a specific problem. Let me know what you think.

This pull request is to fix:

- [`AsyncReadExt::read`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read) does not guarantee number of bytes read
  - [`AsyncReadExt::read_exact`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read_exact) does this
- [`AsyncWriteExt::write`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWriteExt.html#method.write) does not guarantee all bytes are written
  - [`AsyncWriteExt::write_all`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWriteExt.html#method.write_all) does this
- Use [`BytesMut::zeroed`](https://docs.rs/bytes/latest/bytes/struct.BytesMut.html#method.zeroed) to create a zeroed buffer of the given length