### PR TITLE
Update notifications to support closures instead of only static fns

### DIFF
--- a/examples/notification.rs
+++ b/examples/notification.rs
@@ -64,12 +64,27 @@ fn main() {
             cycle_time  : 0  // check for value change each cycle
         };
 
+        let notification_a = {
+            let user_data = buf_n_cnt_a.clone();
+
+            move |_handle: u32, _timestamp: u64, payload: Bytes| {
+                let n_cnt_a = u16::from_ne_bytes(payload[..].try_into().expect("Failed to parse data"));
+                println!("Notification Event!, n_cnt_a: {}", n_cnt_a);
+
+                { // LOCK
+                    let mut user_data = user_data.lock().expect("Threading error");
+                    user_data.clear();
+                    user_data.put(&payload[..]);
+                } // UNLOCK
+            }
+        };
+
         match rt.block_on(ads_client.add_device_notification(   0xF005,
                                                                 var_hdl_a,
                                                                 &ads_notification_attrib_a,
                                                                 &mut not_hdl_a,
                                                                 notification_a,
-                                                                Some(&buf_n_cnt_a)))
+                                                                ))
         {
             Ok(_)     => {
                 println!("Waiting for notifications on n_cnt_a!");
@@ -88,13 +103,28 @@ fn main() {
             max_delay   : 500, // sumup notifications each 500ms
             cycle_time  : 0 // check for value change each cycle
         };
+
+        let notification_b = {
+            let user_data = buf_n_cnt_b.clone();
+
+            move |_handle: u32, _timestamp: u64, payload: Bytes| {
+                let n_cnt_b = u16::from_ne_bytes(payload[..].try_into().expect("Failed to parse data"));
+                println!("Notification Event!, n_cnt_b: {}", n_cnt_b);
+
+                { // LOCK
+                    let mut user_data = user_data.lock().expect("Threading error");
+                    user_data.clear();
+                    user_data.put(&payload[..]);
+                } // UNLOCK
+            }
+        };
         
         match rt.block_on(ads_client.add_device_notification(   0xF005,
                                                                 var_hdl_b,
                                                                 &ads_notification_attrib_b,
                                                                 &mut not_hdl_b,
                                                                 notification_b,
-                                                                Some(&buf_n_cnt_b)))
+                                                                ))
         {
             Ok(_)     => {
                 println!("Waiting for notifications on n_cnt_b!");
@@ -111,13 +141,30 @@ fn main() {
             max_delay   : 100, // sumup notifications each 100ms
             cycle_time  : 0 // check for value change each cycle
         };
+    
+        let notification_c = {
+            let user_data = buf_n_cnt_c.clone();
+
+            move |_handle: u32, _timestamp: u64, payload: Bytes| {
+                let n_cnt_c = u16::from_ne_bytes(payload[..].try_into().expect("Failed to parse data"));
+                if n_cnt_c % 100 == 0 {
+                    println!("Notification Event!, n_cnt_c: {}", n_cnt_c);
+                }
+        
+                { // LOCK
+                    let mut user_data = user_data.lock().expect("Threading error");
+                    user_data.clear();
+                    user_data.put(&payload[..]);
+                } // UNLOCK
+            }
+        };
         
         match rt.block_on(ads_client.add_device_notification(   0xF005,
                                                                 var_hdl_c,
                                                                 &ads_notification_attrib_c,
                                                                 &mut not_hdl_c,
                                                                 notification_c,
-                                                                Some(&buf_n_cnt_c)))
+                                                                ))
         {
             Ok(_)     => {
                 println!("Waiting for notifications on n_cnt_c!");
@@ -176,56 +223,4 @@ fn main() {
         println!("Final value n_cnt_c: {}", n_cnt_c);
     }
 
-}
-
-
-fn notification_a(_handle: u32, _timestamp: u64, payload: Bytes, user_data: Option<Arc<Mutex<BytesMut>>>){
-    let n_cnt_a = u16::from_ne_bytes(payload[..].try_into().expect("Failed to parse data"));
-    println!("Notification Event!, n_cnt_a: {}", n_cnt_a);
-
-    // Process userdata if available
-    if user_data.is_some() {
-        let user_data = user_data.unwrap();
-
-        { // LOCK
-            let mut user_data = user_data.lock().expect("Threading error");
-            user_data.clear();
-            user_data.put(&payload[..]);
-        } // UNLOCK
-    }
-}
-
-fn notification_b(_handle: u32, _timestamp: u64, payload: Bytes, user_data: Option<Arc<Mutex<BytesMut>>>){
-    let n_cnt_b = u16::from_ne_bytes(payload[..].try_into().expect("failed to parse data"));
-    println!("Notification Event!, n_cnt_b: {}", n_cnt_b);
-
-    // Process userdata if available
-    if user_data.is_some() {
-        let user_data = user_data.unwrap();
-
-        { // LOCK
-            let mut user_data = user_data.lock().expect("Threading error");
-            user_data.clear();
-            user_data.put(&payload[..]);
-        } // UNLOCK
-    }
-}
-
-fn notification_c(_handle: u32, _timestamp: u64, payload: Bytes, user_data: Option<Arc<Mutex<BytesMut>>>){
-    let n_cnt_c = u16::from_ne_bytes(payload[..].try_into().expect("failed to parse data"));
-    if n_cnt_c % 100 == 0 {
-        println!("Notification Event!, n_cnt_c: {}", n_cnt_c);
-    }
-    
-
-    // Process userdata if available
-    if user_data.is_some() {
-        let user_data = user_data.unwrap();
-
-        { // LOCK
-            let mut user_data = user_data.lock().expect("Threading error");
-            user_data.clear();
-            user_data.put(&payload[..]);
-        } // UNLOCK
-    }
 }

--- a/examples/notification_async.rs
+++ b/examples/notification_async.rs
@@ -65,12 +65,27 @@ async fn main() -> Result<()> {
             cycle_time  : 0  // check for value change each cycle
         };
 
+        let notification_a = {
+            let user_data = buf_n_cnt_a.clone();
+
+            move |_handle: u32, _timestamp: u64, payload: Bytes| {
+                let n_cnt_a = u16::from_ne_bytes(payload[..].try_into().expect("Failed to parse data"));
+                println!("Notification Event!, n_cnt_a: {}", n_cnt_a);
+
+                { // LOCK
+                    let mut user_data = user_data.lock().expect("Threading error");
+                    user_data.clear();
+                    user_data.put(&payload[..]);
+                } // UNLOCK
+            }
+        };
+
         match ads_client.add_device_notification(   0xF005,
                                                     var_hdl_a,
                                                     &ads_notification_attrib_a,
                                                     &mut not_hdl_a,
                                                     notification_a,
-                                                    Some(&buf_n_cnt_a)).await
+                                                ).await
         {
             Ok(_)     => {
                 println!("Waiting for notifications on n_cnt_a!");
@@ -89,13 +104,28 @@ async fn main() -> Result<()> {
             max_delay   : 500, // sumup notifications each 500ms
             cycle_time  : 0 // check for value change each cycle
         };
+
+        let notification_b = {
+            let user_data = buf_n_cnt_b.clone();
+
+            move |_handle: u32, _timestamp: u64, payload: Bytes| {
+                let n_cnt_b = u16::from_ne_bytes(payload[..].try_into().expect("Failed to parse data"));
+                println!("Notification Event!, n_cnt_b: {}", n_cnt_b);
+
+                { // LOCK
+                    let mut user_data = user_data.lock().expect("Threading error");
+                    user_data.clear();
+                    user_data.put(&payload[..]);
+                } // UNLOCK
+            }
+        };
         
         match ads_client.add_device_notification(   0xF005,
                                                     var_hdl_b,
                                                     &ads_notification_attrib_b,
                                                     &mut not_hdl_b,
                                                     notification_b,
-                                                    Some(&buf_n_cnt_b)).await
+                                                ).await
         {
             Ok(_)     => {
                 println!("Waiting for notifications on n_cnt_b!");
@@ -112,13 +142,30 @@ async fn main() -> Result<()> {
             max_delay   : 100, // sumup notifications each 100ms
             cycle_time  : 0 // check for value change each cycle
         };
+
+        let notification_c = {
+            let user_data = buf_n_cnt_c.clone();
+
+            move |_handle: u32, _timestamp: u64, payload: Bytes| {
+                let n_cnt_c = u16::from_ne_bytes(payload[..].try_into().expect("Failed to parse data"));
+                if n_cnt_c % 100 == 0 {
+                    println!("Notification Event!, n_cnt_c: {}", n_cnt_c);
+                }
+        
+                { // LOCK
+                    let mut user_data = user_data.lock().expect("Threading error");
+                    user_data.clear();
+                    user_data.put(&payload[..]);
+                } // UNLOCK
+            }
+        };
         
         match ads_client.add_device_notification(   0xF005,
                                                     var_hdl_c,
                                                     &ads_notification_attrib_c,
                                                     &mut not_hdl_c,
                                                     notification_c,
-                                                    Some(&buf_n_cnt_c)).await
+                                                ).await
         {
             Ok(_)     => {
                 println!("Waiting for notifications on n_cnt_c!");
@@ -177,56 +224,4 @@ async fn main() -> Result<()> {
         println!("Final value n_cnt_c: {}", n_cnt_c);
     }
     Ok(())
-}
-
-
-fn notification_a(_handle: u32, _timestamp: u64, payload: Bytes, user_data: Option<Arc<Mutex<BytesMut>>>){
-    let n_cnt_a = u16::from_ne_bytes(payload[..].try_into().expect("Failed to parse data"));
-    println!("Notification Event!, n_cnt_a: {}", n_cnt_a);
-
-    // Process userdata if available
-    if user_data.is_some() {
-        let user_data = user_data.unwrap();
-
-        { // LOCK
-            let mut user_data = user_data.lock().expect("Threading error");
-            user_data.clear();
-            user_data.put(&payload[..]);
-        } // UNLOCK
-    }
-}
-
-fn notification_b(_handle: u32, _timestamp: u64, payload: Bytes, user_data: Option<Arc<Mutex<BytesMut>>>){
-    let n_cnt_b = u16::from_ne_bytes(payload[..].try_into().expect("failed to parse data"));
-    println!("Notification Event!, n_cnt_b: {}", n_cnt_b);
-
-    // Process userdata if available
-    if user_data.is_some() {
-        let user_data = user_data.unwrap();
-
-        { // LOCK
-            let mut user_data = user_data.lock().expect("Threading error");
-            user_data.clear();
-            user_data.put(&payload[..]);
-        } // UNLOCK
-    }
-}
-
-fn notification_c(_handle: u32, _timestamp: u64, payload: Bytes, user_data: Option<Arc<Mutex<BytesMut>>>){
-    let n_cnt_c = u16::from_ne_bytes(payload[..].try_into().expect("failed to parse data"));
-    if n_cnt_c % 100 == 0 {
-        println!("Notification Event!, n_cnt_c: {}", n_cnt_c);
-    }
-    
-
-    // Process userdata if available
-    if user_data.is_some() {
-        let user_data = user_data.unwrap();
-
-        { // LOCK
-            let mut user_data = user_data.lock().expect("Threading error");
-            user_data.clear();
-            user_data.put(&payload[..]);
-        } // UNLOCK
-    }
 }

--- a/src/ads_add_device_notification.rs
+++ b/src/ads_add_device_notification.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 use bytes::{Bytes, BytesMut};
 use log::info;
-use crate::{Client, AdsCommand, AdsError, AdsErrorCode, Notification, AdsNotificationAttrib, HEADER_SIZE, LEN_ADD_DEV_NOT, Result, misc::HandleData};
+use crate::{AdsCommand, AdsError, AdsErrorCode, AdsNotificationAttrib, Client, HEADER_SIZE, LEN_ADD_DEV_NOT, Notification, Result, misc::{HandleData, NotificationCallback}};
 
 impl Client {
 
@@ -26,7 +26,7 @@ impl Client {
         _add_not_req.freeze()
     }
 
-    fn post_add_dev_not(&self, add_dev_not_response : HandleData, handle: &mut u32, callback : Notification, user_data: Option<&Arc<Mutex<BytesMut>>>) -> Result<()>{
+    fn post_add_dev_not(&self, add_dev_not_response : HandleData, handle: &mut u32, callback : Notification) -> Result<()>{
 
         let payload = add_dev_not_response.payload
                         .ok_or_else(|| AdsError{n_error : AdsErrorCode::ADSERR_DEVICE_INVALIDDATA.into(), s_msg : String::from("Invalid data values.")})?;
@@ -40,7 +40,7 @@ impl Client {
         // Check if registration of device notification was successfull
         if *handle != 0 {
             // Register notification handle
-            self.register_not_handle(*handle, callback, user_data);
+            self.register_not_handle(*handle, callback);
         }
         Ok(())
     }
@@ -48,7 +48,7 @@ impl Client {
     /// 
     /// Checkout the extensive examples [notification](https://github.com/hANSIc99/ads_client/blob/main/examples/notification.rs) 
     /// and [notification_async](https://github.com/hANSIc99/ads_client/blob/main/examples/notification_async.rs).
-    pub async fn add_device_notification(&self, idx_grp: u32, idx_offs: u32, attributes : &AdsNotificationAttrib, handle: &mut u32, callback : Notification, user_data: Option<&Arc<Mutex<BytesMut>>> ) -> Result<()>{
+    pub async fn add_device_notification<Callback: NotificationCallback>(&self, idx_grp: u32, idx_offs: u32, attributes : &AdsNotificationAttrib, handle: &mut u32, callback : Callback ) -> Result<()>{
         // Prepare AddDeviceNotification request
         let invoke_id = self.create_invoke_id();
         let _add_not_req = self.pre_add_dev_not(idx_grp, idx_offs, attributes, invoke_id);
@@ -64,7 +64,7 @@ impl Client {
         let socket_future = self.socket_write(&_add_not_req);
 
         tokio::try_join!(cmd_man_future, socket_future).and_then( | (add_not_response, _) | {
-            self.post_add_dev_not(add_not_response, handle, callback, user_data)
+            self.post_add_dev_not(add_not_response, handle, Notification::new(callback))
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,13 +432,12 @@ impl Client {
         }
     }
 
-    fn register_not_handle(&self, not_hdl: u32, callback: Notification, user_data: Option<&Arc<Mutex<BytesMut>>>) {
+    fn register_not_handle(&self, not_hdl: u32, callback: Notification) {
         let a_not_handles = Arc::clone(&self.not_handles);
 
         let not_hdl = NotHandle {
             callback  : callback,
             not_hdl   : not_hdl,
-            user_data : user_data.and_then(|arc_bytes| Some(Arc::clone(arc_bytes)) )
         };
 
         {
@@ -623,7 +622,7 @@ impl Client {
                     return;
                 }
 
-                let mut _cb_and_data : Option<(Notification, Option<Arc<Mutex<BytesMut>>>)> = None;
+                let mut _cb : Option<Notification> = None;
                 
                 // The callback must be called after the lock. 
                 // If it is called during the lock, it could block the access to the notification handles infinitely.
@@ -632,18 +631,18 @@ impl Client {
                     let mut _not_handles = not_register.lock().expect("Threading Error");
                     let mut _iter = _not_handles.iter_mut();
                     
-                    _cb_and_data = _iter.find( | hdl | hdl.not_hdl  == not_sample.not_hdl)
-                            .and_then(| hdl : &mut NotHandle | Some( (hdl.callback, hdl.user_data.clone()) ) ); // Return callback and user data
+                    _cb = _iter.find( | hdl | hdl.not_hdl  == not_sample.not_hdl)
+                            .and_then(| hdl : &mut NotHandle | Some( hdl.callback.clone() ) ); // Return callback and user data
                 } // UNLOCK
                 
                 
-                _cb_and_data.and_then(|(callback, user_data)| {
+                _cb.and_then(|callback| {
                     let payload = Bytes::from(data.slice(stamp_header_offset..stamp_header_offset + not_sample.sample_size as usize));
                     // let n_cnt = u16::from_ne_bytes(payload[..].try_into().expect("Failed to parse data")); // DEBUG
 
                     Some(
                             rt.spawn(async move  {
-                            callback(not_sample.not_hdl, stamp_header.timestamp, payload, user_data);
+                            callback.call(not_sample.not_hdl, stamp_header.timestamp, payload);
                         })
                     )
                     

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -53,13 +53,35 @@ pub type AmsNetId = [u8; 6];
 pub type Result<T> = std::result::Result<T, AdsError>;
 
 /// Type definition for notification callback.
-/// 
+///
 /// Arguments:
 /// 1. Handle
 /// 2. Timestamp
 /// 3. Value of monitored variable
-/// 4. User data
-pub type Notification = fn(u32, u64, Bytes, Option<Arc<Mutex<BytesMut>>>) -> (); // handle, timestamp and user data
+pub trait NotificationCallback: Fn(u32, u64, Bytes) + Send + Sync + 'static {}
+
+impl<T> NotificationCallback for T where T: Fn(u32, u64, Bytes) + Send + Sync + 'static {}
+
+
+#[derive(Clone)]
+pub struct Notification(Arc<Box<dyn NotificationCallback>>);
+
+impl Notification {
+    pub fn new<Callback: NotificationCallback>(callback: Callback) -> Self {
+        Self(Arc::new(Box::new(callback)))
+    }
+
+    pub fn call(&self, handle: u32, timestamp: u64, payload: Bytes) {
+        let mut f = &self.0;
+        f(handle, timestamp, payload)
+    }
+}
+
+impl std::fmt::Debug for Notification {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<function>")
+    }
+}
 
 /// Error type of returned Result
 ///  
@@ -178,7 +200,6 @@ pub struct Handle {
 pub struct NotHandle {
     pub callback  : Notification,
     pub not_hdl   : u32,
-    pub user_data : Option<Arc<Mutex<BytesMut>>>,
 }
 /// Specifies the maximum waiting time for an ADS response.
 /// 


### PR DESCRIPTION
Hi, here's another pull request to change notification callbacks.

The current way only supports notification callbacks that are statically defined `fn`s. It also allows you to update user data, but only in a specific, limited way.

Our use case is we want our functions to be closures that mutate data at the same scope as the closure.

This change allows you to pass in closures, which may mutate data inside. This means we no longer need the existing hard-coded user data, since you could provide your own mutable user data with the closure.

Again, this is so far untested, but keen to start a conversation about the change.

Thanks!